### PR TITLE
corrected docstring

### DIFF
--- a/boxview/boxview.py
+++ b/boxview/boxview.py
@@ -291,7 +291,7 @@ class BoxView(object):
 
     @staticmethod
     def get_session_url(session_id, type='view', **params):
-        """ Allowed types are: `view`, `assets`, `download`. """
+        """ Allowed types are: `view`, `assets`, `content`. """
         url = 'sessions/{}/{}'.format(session_id, type)
         url = urljoin(API_URL, url)
         return add_to_url(url, **params)


### PR DESCRIPTION
The final allowed type is 'content'.  

What do you think about raising a ValueError if `type` is not in a list of valid options, similar to the implementation of `allowed_extensions` in `get_document_content()`?