### PR TITLE
add reasonable chunk size for reading from view api endpoints

### DIFF
--- a/boxview/boxview.py
+++ b/boxview/boxview.py
@@ -15,6 +15,7 @@ from .utils import (
 
 __all__ = ['BoxView', 'BoxViewError', 'RetryAfter']
 
+DOWNLOAD_CHUNK_SIZE = 1024
 
 API_VERSION = '1'
 BASE_API_URL = 'https://view-api.box.com/'
@@ -205,7 +206,7 @@ class BoxView(object):
         }
         response = self.request('GET', url, params=params)
 
-        for chunk in response.iter_content():
+        for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
             stream.write(chunk)
 
         return get_mimetype_from_headers(response.headers)
@@ -233,7 +234,7 @@ class BoxView(object):
 
         response = self.request('GET', url, stream=True)
 
-        for chunk in response.iter_content():
+        for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
             stream.write(chunk)
 
         return get_mimetype_from_headers(response.headers)


### PR DESCRIPTION
I noticed that using get_document_content to write to a StringIO was very slow, it turns out the default chunk size for response.iter_content is 1, meaning it was writing one byte at a time.